### PR TITLE
installed node-notifier in services

### DIFF
--- a/src/code-templates/services/order-service/package.json
+++ b/src/code-templates/services/order-service/package.json
@@ -28,6 +28,7 @@
     "axios": "^0.26.1",
     "express": "^4.17.3",
     "jsonwebtoken": "^8.5.1",
+    "node-notifier": "^10.0.1",
     "pg": "^8.7.3",
     "sequelize": "^6.17.0",
     "sequelize-cli": "^6.4.1"


### PR DESCRIPTION
Added node-notifier in services.
Without it we had to install node-notifier explicitly in services (nmp I wouldn't install it).
And tests wouldn't pass if you generate the app not in main root folder.