### PR TITLE
feat(cli): generate turborepo tooling if requested by user

### DIFF
--- a/src/code-generator/entry-points/cli-entry-point.ts
+++ b/src/code-generator/entry-points/cli-entry-point.ts
@@ -23,6 +23,7 @@ export function startAppGenerator() {
     .option("-d, --db <string>", "DB to use")
     .option("-id, --install-dependencies", "Whether to install dependencies")
     .option("-ov, --override-if-exists", "If set to true, the existing generated app will be overriden")
+    .option("-mt --monorepo-tool <string>", 'If set to "turborepo" generates configuration to run tasks in a monorepo')
     .action((options) => {
       handleNonInteractiveCommand(options);
     });

--- a/src/code-generator/entry-points/interactive-cli.tsx
+++ b/src/code-generator/entry-points/interactive-cli.tsx
@@ -20,6 +20,7 @@ const QuestionsWizard = () => {
     showNameQuestion: false,
     showFrameworkQuestion: false,
     showDBTypeQuestion: false,
+    showMonorepoToolQuestion: false,
     showFeatures: false,
     advice: "",
     title: figlet.textSync("Practica", {
@@ -87,6 +88,19 @@ const QuestionsWizard = () => {
     },
   ];
 
+  const monorepoTools = [
+    {
+      label: "Turborepo",
+      value: "turborepo",
+      advice:
+          "A fast monorepo task-runner that can work with all popular package managers (npm, pnpm, yarn)",
+    },
+    {
+      label: "None",
+      value: 'none',
+    },
+  ]
+
   const frameworks = [
     {
       label: "Express",
@@ -149,6 +163,7 @@ const QuestionsWizard = () => {
       installDependencies: true,
       targetDirectory: process.cwd(),
       baseFramework: questionsWizard.chosenFramework,
+      monorepoTool: questionsWizard.chosenMonorepoTool,
     });
     await generateService.generateApp(generationOptions);
     setQuestionsWizard({
@@ -164,12 +179,21 @@ const QuestionsWizard = () => {
       ...questionsWizard,
       chosenDB: chosenOption.value,
       showDBTypeQuestion: false,
+      showMonorepoToolQuestion: true,
+    });
+  };
+
+  const handleMonorepoToolChoose = async (chosenOption) => {
+    setQuestionsWizard({
+      ...questionsWizard,
+      chosenMonorepoTool: chosenOption.value === 'none' ? undefined : chosenOption.value,
+      showMonorepoToolQuestion: false,
       showFlavourQuestion: true,
     });
   };
 
   const onSelectItemChange = (selectedItem) => {
-    const allOptions = [...databases, ...frameworks, ...flavours];
+    const allOptions = [...databases, ...frameworks, ...flavours, ...monorepoTools];
     const chosenItem = allOptions.find(
       (option) => option.value === selectedItem.value
     )?.advice;
@@ -286,6 +310,26 @@ const QuestionsWizard = () => {
                   </Box>
                 ) : (
                   <React.Fragment />
+                )}
+
+                {questionsWizard.showMonorepoToolQuestion ? (
+                    <Box
+                        display={
+                          questionsWizard.showMonorepoToolQuestion ? "flex" : "none"
+                        }
+                    >
+                      <Text color="green">Which monorepo tooling do you want?</Text>
+                      <Spacer />
+                      <SelectInput
+                          items={monorepoTools}
+                          onSelect={handleMonorepoToolChoose}
+                          onChange={onSelectItemChange}
+                          onSelectItemChange={onSelectItemChange}
+                          onHighlight={onSelectItemChange}
+                      />
+                    </Box>
+                ) : (
+                    <React.Fragment />
                 )}
 
                 {questionsWizard.showFrameworkQuestion ? (

--- a/src/code-generator/entry-points/non-interactive-cli.tsx
+++ b/src/code-generator/entry-points/non-interactive-cli.tsx
@@ -4,10 +4,12 @@ import { generateApp } from "../generation-logic/generate-service";
 
 export async function handleNonInteractiveCommand(options: any) {
   try {
+
     const generationOptions = factorDefaultOptions({
       installDependencies: options.installDependencies,
       overrideIfExists: options.overrideIfExists,
       targetDirectory: process.cwd(),
+      monorepoTool: options.monorepoTool,
     });
     await generateApp(generationOptions);
   } catch (error: AppError | any) {

--- a/src/code-generator/generation-logic/generate-monorepo-tool.ts
+++ b/src/code-generator/generation-logic/generate-monorepo-tool.ts
@@ -1,0 +1,44 @@
+import {generationOptions} from "./generation-options";
+import * as path from "path";
+import * as fs from "fs";
+import {promisify} from 'util';
+import fsExtra from "fs-extra";
+
+type GenerateMonorepoToolOptions = {
+    monorepoTool: generationOptions['monorepoTool'];
+    dest: string;
+    source: string;
+}
+
+async function addWorkspaceConfigToPkgJson(path: string) {
+    try {
+        const contentsAsString = (await promisify(fs.readFile)(path)).toString();
+        const contentsAsJson = JSON.parse(contentsAsString);
+        contentsAsJson.workspaces = ["libraries/**/*", "services/**/*"];
+        await promisify(fs.writeFile)(path, JSON.stringify(contentsAsJson, undefined, 4));
+    } catch (e: any) {
+        throw new Error(`Failed to add "workspaces" configuration to package.json file at ${path}. Cause: ${e?.message}`);
+    }
+}
+
+type AddTurboRepoConfigFile = {
+    dest: string,
+    source: string,
+}
+
+async function addTurboRepoConfigFile(params: AddTurboRepoConfigFile) {
+    const sourceFile = path.join(params.source, 'optionalAdditions', 'turbo.json');
+    const targetFile = path.join(params.dest, 'turbo.json');
+    await fsExtra.copy(sourceFile, targetFile);
+}
+
+export async function generateMonorepoTool(options: GenerateMonorepoToolOptions) {
+    const {monorepoTool, dest} = options;
+    if (monorepoTool !== 'turborepo') {
+        return;
+    } else {
+        const pkgJsonPath = path.join(dest, 'package.json');
+        await addWorkspaceConfigToPkgJson(pkgJsonPath);
+        await addTurboRepoConfigFile(options);
+    }
+}

--- a/src/code-generator/generation-logic/generation-options.ts
+++ b/src/code-generator/generation-logic/generation-options.ts
@@ -7,6 +7,7 @@ export type generationOptions = {
   targetDirectory: string;
   installDependencies: boolean;
   overrideIfExists: boolean;
+  monorepoTool: undefined | '' | 'turborepo';
 };
 
 export const factorDefaultOptions = (
@@ -21,6 +22,7 @@ export const factorDefaultOptions = (
     targetDirectory: process.cwd(),
     installDependencies: false,
     overrideIfExists: true,
+    monorepoTool: 'turborepo',
   };
 
   const result = Object.assign(defaults, overrides);

--- a/src/code-templates/lerna.json
+++ b/src/code-templates/lerna.json
@@ -1,4 +1,0 @@
-{
-  "packages": ["libraries/*", "services/*"],
-  "version": "independent"
-}

--- a/src/code-templates/optionalAdditions/turbo.json
+++ b/src/code-templates/optionalAdditions/turbo.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "baseBranch": "origin/main",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [
+        ".dist/**"
+      ]
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": [".coverage/**"]
+    }
+  }
+}

--- a/src/code-templates/package.json
+++ b/src/code-templates/package.json
@@ -7,7 +7,6 @@
     "test": "lerna run --parallel --scope order-service test",
     "build": "tsc",
     "build:watch": "tsc --watch",
-    "lerna": "lerna",
     "maintenance:delete-node-modules": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +"
   },
   "author": "",
@@ -20,6 +19,6 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "lerna": "^4.0.0"
+    "turbo": "^1.3.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,7 +45,7 @@
     // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
     "outDir": ".dist/" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */


### PR DESCRIPTION
- Added new cli/interactive flag --monorepo-tool which currently supports either: no value, "turborepo"
- If the flag's value is "turborepo", the example repo will be generated with basic npm workspace + turborepo configuration
- The configuration contains a turborepo pipeline for "build" and "test" commands
- Also added sourcemaps for CLI code for easier debugging

closes #80

Open issues before merging:
- [ ] Requires testing for all flag values: correct codegen, basic commands work after generation (install, build, test)
- [ ] For some reason, after codegen the first "npm install" fails, but after the 1st one's faliure - everything works correctly 