### PR TITLE
Remove extra characters from code example

### DIFF
--- a/docs/blog/pattern-to-reconsider/index.md
+++ b/docs/blog/pattern-to-reconsider/index.md
@@ -447,7 +447,7 @@ if (process.env.NODE_ENV === "production") {
 ```javascript
 //package.json
 "scripts": {
-    "start": "LOG_PRETTY_PRINT=false index.js",gh 
+    "start": "LOG_PRETTY_PRINT=false index.js",
     "test": "LOG_PRETTY_PRINT=true jest"
 }
 


### PR DESCRIPTION
There were some extra characters in a JSON code example.